### PR TITLE
Fix for broken navigation on team page

### DIFF
--- a/src/components/Team/Team.test.tsx
+++ b/src/components/Team/Team.test.tsx
@@ -1,5 +1,5 @@
 import { getTeamById } from '@/services/teamService';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -234,6 +234,24 @@ describe('Team', () => {
       // One tab should be selected, one should not
       expect(driversTab).toHaveAttribute('aria-selected', 'true');
       expect(constructorsTab).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('Navigation', () => {
+    it('renders breadcrumb navigation to dashboard', () => {
+      // Test that the link exists with correct attributes
+      const dashboardLink = screen.getByRole('link', { name: /back to league/i });
+      expect(dashboardLink).toBeInTheDocument();
+      expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('provides accessible breadcrumb navigation', () => {
+      // Test ARIA compliance
+      const breadcrumb = screen.getByRole('navigation', { name: /breadcrumb/i });
+      expect(breadcrumb).toBeInTheDocument();
+
+      const dashboardLink = within(breadcrumb).getByRole('link', { name: /back to league/i });
+      expect(dashboardLink).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Team/Team.tsx
+++ b/src/components/Team/Team.tsx
@@ -43,7 +43,7 @@ export function Team() {
       <header className="mb-4">
         <nav aria-label="Breadcrumb" className="mb-4">
           <Link
-            to={`/`}
+            to={`/dashboard`}
             className="text-muted-foreground hover:text-foreground inline-flex items-center text-sm transition-colors"
           >
             <ChevronLeft />


### PR DESCRIPTION
This pull request enhances the `Team` component by improving its breadcrumb navigation for better accessibility and user experience. The main changes include updating the breadcrumb link to point to the dashboard and adding tests to ensure the navigation is present and accessible.

**Breadcrumb navigation improvements:**

* Changed the breadcrumb link in `Team.tsx` to point to `/dashboard` instead of `/` for more accurate navigation.

**Accessibility and testing enhancements:**

* Added tests in `Team.test.tsx` to verify the presence and accessibility of the breadcrumb navigation, including ARIA compliance and correct link attributes.
* Imported the `within` utility from Testing Library to facilitate more precise queries within the breadcrumb navigation in tests.